### PR TITLE
Adds the ability to specify a suffix that gets added to every column

### DIFF
--- a/src/fields/TableMakerField.php
+++ b/src/fields/TableMakerField.php
@@ -125,9 +125,11 @@ class TableMakerField extends Field
                     <tr>
         ';
 
-        if ( !empty($value['columns']) )
+        // Disregard bad keys...
+        $columns = empty($value['columns']) ? [] : array_values($value['columns']);
+        if ( !empty($columns) )
         {
-            foreach ($value['columns'] as $col)
+            foreach ($columns as $col)
             {
                 $html .= '<th align="' . $col['align'] . '" width="' . $col['width'] . '">' . $col['heading'] . '</th>';
             }
@@ -151,7 +153,7 @@ class TableMakerField extends Field
 
                 $i = 0;
                 foreach ($row as $cell) {
-                    $align = $value['columns']['col'.$i]['align'] ?? $value['columns'][$i]['align'];
+                    $align = $columns[$i]['align'];
                     $html .= '<td align="' . $align . '">' . $cell . '</td>';
                     $i++;
                 }

--- a/src/fields/TableMakerField.php
+++ b/src/fields/TableMakerField.php
@@ -131,7 +131,16 @@ class TableMakerField extends Field
         {
             foreach ($columns as $col)
             {
-                $html .= '<th align="' . $col['align'] . '" width="' . $col['width'] . '">' . $col['heading'] . '</th>';
+                $html .= '<th';
+                if (!empty($col['align'])) {
+                    $html .= ' align="' . $col['align'] . '"';
+                }
+                
+                if (!empty($col['width'])) {
+                    $html .= ' width="' . $col['width'] . '"';
+                }
+                
+                $html .= '>' . $col['heading'] . '</th>';
             }
         }
 
@@ -154,7 +163,17 @@ class TableMakerField extends Field
                 $i = 0;
                 foreach ($row as $cell) {
                     $align = $columns[$i]['align'];
-                    $html .= '<td align="' . $align . '">' . $cell . '</td>';
+                    $html .= '<td';
+                    if (!empty($align)) {
+                        $html .= ' align="' . $align . '"';
+                    }
+                    $html .= '>' . $cell;
+
+                    if (!empty($columns[$i]['cellSuffix'])) {
+                        $html .= '<small class="suffix">' . $columns[$i]['cellSuffix'] . '</small>';
+                    }
+
+                    $html .= '</td>';
                     $i++;
                 }
 
@@ -271,6 +290,7 @@ class TableMakerField extends Field
                     'heading' => $val['heading'],
                     'align' => $val['align'],
                     'width' => $val['width'],
+                    'cellSuffix' => $val['cellSuffix'] ?? '',
                     'type' => 'singleline'
                 );
             }
@@ -282,6 +302,7 @@ class TableMakerField extends Field
                     'heading' => '',
                     'align' => '',
                     'width' => '',
+                    'cellSuffix' => '',
                     'type' => 'singleline'
                 )
             );
@@ -310,11 +331,17 @@ class TableMakerField extends Field
                 'heading' => Craft::t('tablemaker', 'Heading'),
                 'type' => 'singleline'
             ),
+            'cellSuffix' => [
+                'heading' => Craft::t('tablemaker', 'Cell Suffix'),
+                'class' => 'code',
+                'type' => 'singleline',
+                'width' => 30
+            ],
             'width' => array(
                 'heading' => Craft::t('tablemaker', 'Width'),
                 'class' => 'code',
-                'type' => 'singleline',
-                'width' => 50
+                'type' => 'number',
+                'width' => 30,
             ),
             'align' => array(
                 'heading' => Craft::t('tablemaker', 'Alignment'),
@@ -325,7 +352,7 @@ class TableMakerField extends Field
                     'center' => Craft::t('tablemaker', 'Center'),
                     'right'  => Craft::t('tablemaker', 'Right')
                 )
-            )
+            ),
         );
 
         // init the js


### PR DESCRIPTION
Allows columns to say be numbers, but be rendered at the template level with a suffix

1. In the columns table, add "Mbps" as a suffix for a number field.
2. In the rows table, add a value of "2".
3. In your template do something like the following:

```
    <table>
       <thead>
            <tr>
                {% for column in block.table.columns -%}
                    <th>{{ column.heading }}</th>
                {% endfor -%}
            </tr>
        </thead>
        <tbody>
            {% for row in block.table.rows -%}
                <tr>
                    {% for i in 0 ..(row | length - 1) -%}
                        <td>
                            {% switch block.table.columns[i].type %}
                                ...
                                {% case "number" %}
                                    {{ row[i] }}
                                    {% if block.table.columns[i].cellSuffix is not empty %}
                                        <span class="cell-suffix">{{ block.table.columns[i].cellSuffix }}</span>
                                    {%- endif %}
                                ...
                            {% endswitch %}
                        </td>
                    {% endfor -%}
                </tr>
            {% endfor -%}
        </tbody>
    </table>
```

Thus, you can customize the suffix, say by making it appear as a subscript or whatever.