### PR TITLE
Adds GraphQL support.

### DIFF
--- a/src/fields/TableMakerField.php
+++ b/src/fields/TableMakerField.php
@@ -226,6 +226,16 @@ class TableMakerField extends Field
     public function getContentGqlType()
     {
         $typeName = $this->handle . '_TableMakerField';
+        $columnTypeName = 'TableMakerFieldColumn';
+
+        $columnType = GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($columnTypeName, new ObjectType([
+            'name' => $columnTypeName,
+            'fields' => [
+                'heading' => Type::string(),
+                'width' => Type::string(),
+                'align' => Type::string(),
+            ],
+        ]));
 
         $tableMakerType = GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new ObjectType([
             'name' => $typeName,
@@ -234,22 +244,13 @@ class TableMakerField extends Field
                     'type' => Type::listOf(Type::listOf(Type::string()))
                 ],
                 'columns' => [
-                    'type' => Type::listOf(new ObjectType([
-                        'name' => $this->handle . '_column',
-                        'fields' => [
-                            'heading' => Type::string(),
-                            'width' => Type::string(),
-                            'align' => Type::string(),
-                        ],
-                    ])),
+                    'type' => Type::listOf($columnType),
                 ],
                 'table' => [
                     'type' => Type::string()
                 ]
             ]
         ]));
-
-        TypeLoader::registerType($typeName, function () use ($tableMakerType) { return $tableMakerType ;});
 
         return $tableMakerType;
     }

--- a/src/fields/TableMakerField.php
+++ b/src/fields/TableMakerField.php
@@ -21,6 +21,8 @@ use craft\helpers\Db;
 use yii\db\Schema;
 use craft\helpers\Json;
 use craft\helpers\Template;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
 
 /**
  * @author    Supercool Ltd

--- a/src/fields/TableMakerField.php
+++ b/src/fields/TableMakerField.php
@@ -16,6 +16,7 @@ use supercool\tablemaker\assetbundles\field\FieldAsset;
 use Craft;
 use craft\base\ElementInterface;
 use craft\base\Field;
+use craft\gql\TypeLoader;
 use yii\db\Schema;
 use craft\helpers\Json;
 use craft\helpers\Template;
@@ -247,6 +248,8 @@ class TableMakerField extends Field
                 ]
             ]
         ]));
+
+        TypeLoader::registerType($typeName, function () use ($tableMakerType) { return $tableMakerType ;});
 
         return $tableMakerType;
     }

--- a/src/fields/TableMakerField.php
+++ b/src/fields/TableMakerField.php
@@ -218,6 +218,36 @@ class TableMakerField extends Field
 
 
     /**
+     * @inheritdoc
+     * @since 3.3.0
+     */
+    public function getContentGqlType()
+    {
+        return new ObjectType([
+            'name' => $this->handle,
+            'fields' => [
+                'rows' => [
+                    'type' => Type::listOf(Type::listOf(Type::string()))
+                ],
+                'columns' => [
+                    'type' => Type::listOf(new ObjectType([
+                        'name' => $this->handle . '_column',
+                        'fields' => [
+                            'heading' => Type::string(),
+                            'width' => Type::string(),
+                            'align' => Type::string(),
+                        ],
+                    ])),
+                ],
+                'table' => [
+                    'type' => Type::string()
+                ]
+            ]
+        ]);
+    }
+
+
+    /**
      * Returns the component’s settings HTML.
      *
      * @return string|null

--- a/src/fields/TableMakerField.php
+++ b/src/fields/TableMakerField.php
@@ -226,7 +226,7 @@ class TableMakerField extends Field
     public function getContentGqlType()
     {
         $typeName = $this->handle . '_TableMakerField';
-        $columnTypeName = 'TableMakerFieldColumn';
+        $columnTypeName = $typeName . '_column';
 
         $columnType = GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($columnTypeName, new ObjectType([
             'name' => $columnTypeName,

--- a/src/fields/TableMakerField.php
+++ b/src/fields/TableMakerField.php
@@ -11,18 +11,17 @@
 
 namespace supercool\tablemaker\fields;
 
-use supercool\tablemaker\TableMaker;
 use supercool\tablemaker\assetbundles\field\FieldAsset;
 
 use Craft;
 use craft\base\ElementInterface;
 use craft\base\Field;
-use craft\helpers\Db;
 use yii\db\Schema;
 use craft\helpers\Json;
 use craft\helpers\Template;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
+use craft\gql\GqlEntityRegistry;
 
 /**
  * @author    Supercool Ltd
@@ -225,8 +224,10 @@ class TableMakerField extends Field
      */
     public function getContentGqlType()
     {
-        return new ObjectType([
-            'name' => $this->handle,
+        $typeName = $this->handle . '_TableMakerField';
+
+        $tableMakerType = GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new ObjectType([
+            'name' => $typeName,
             'fields' => [
                 'rows' => [
                     'type' => Type::listOf(Type::listOf(Type::string()))
@@ -245,7 +246,9 @@ class TableMakerField extends Field
                     'type' => Type::string()
                 ]
             ]
-        ]);
+        ]));
+
+        return $tableMakerType;
     }
 
 


### PR DESCRIPTION
This is my first attempt to add first-party GraphQL support to *any* plugin, but it works great locally. Any given Table Maker field can be queried for its rows, columns, or table markup. If the field handle is `myTable`, for example, a GraphQL query could include...

```graphql
myTable {
  rows
  columns {
    heading
    width
    align
  }
  table
}
```

...and the response would be something like...

```json
{
  "myTable": {
    "rows": [
      [
        "Vultr 32GB",
        "$160/month",
      ],
      [
        "Digital Ocean 16GB CPU",
        "$160/month",
      ],
      [
        "AWS m5.2xlarge",
        "$262.08/month",
      ],
      [
        "Digital Ocean 32GB",
        "$160/month",
      ],
      [
        "Linode 32GB",
        "$160/month",
      ]
    ],
    "columns": [
      {
        "heading": "Provider+Plan",
        "width": "",
        "align": "left"
      },
      {
        "heading": "Cost",
        "width": "",
        "align": "left"
      },
    ],
    "table": "\n            <table>\n                <thead>\n                    <tr>\n        <th align=\"left\" width=\"\">Provider+Plan</th><th align=\"left\" width=\"\">Xeon CPU</th><th align=\"left\" width=\"\">RAM</th><th align=\"left\" width=\"\">Storage</th><th align=\"left\" width=\"\">Cost</th><th align=\"left\" width=\"\">Location</th>\n                    </tr>\n                </thead>\n\n                <tbody>\n\n        <tr><td align=\"left\">Vultr 32GB</td><td align=\"left\">$160/month</td></tr><tr><td align=\"left\">Digital Ocean 16GB CPU</td><td align=\"left\">$160/month</td></tr><tr><td align=\"left\">AWS m5.2xlarge</td><td align=\"left\">$262.08/month</td></tr><tr><td align=\"left\">Digital Ocean 32GB</td><td align=\"left\">$160/month</td></tr><tr><td align=\"left\">Linode 32GB</td><td align=\"left\">$160/month</td></tr><tr>\n\n                </tbody>\n\n            </table>\n        "
  }
}
```