### PR TITLE
Add migrations for Craft 2

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -1,0 +1,40 @@
+<?php
+namespace supercool\tablemaker\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Query;
+
+class Install extends Migration
+{
+    public function safeUp()
+    {
+        if ($this->_upgradeFromCraft2()) {
+            return;
+        }
+    }
+
+    private function _upgradeFromCraft2(): bool
+    {
+        $row = (new Query())
+            ->select(['id', 'handle'])
+            ->from(['{{%plugins}}'])
+            ->where(['in', 'handle', ['table-maker', 'tablemaker']])
+            ->one();
+
+        if (!$row) {
+            return false;
+        }
+
+        $projectConfig = Craft::$app->projectConfig;
+
+        $oldKey = "plugins.{$row['handle']}";
+        $newKey = 'plugins.tablemaker';
+        $projectConfig->set($newKey, $projectConfig->get($oldKey));
+
+        $this->delete('{{%plugins}}', ['id' => $row['id']]);
+        $projectConfig->remove($oldKey);
+
+        return true;
+    }
+}

--- a/src/migrations/m190412_182837_update_craft2_fieldtype.php
+++ b/src/migrations/m190412_182837_update_craft2_fieldtype.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace craft\contentmigrations;
+
+use craft\db\Migration;
+use supercool\tablemaker\fields\TableMakerField;
+
+/**
+ * m190412_182837_update_craft2_fieldtype migration.
+ *
+ * Updates previous TableMaker fields from Craft 2
+ *
+ */
+class m190412_182837_update_craft2_fieldtype extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        echo "    > Updating Table Maker field type...\n";
+
+        $this->update('{{%fields}}', [
+            'type' => TableMakerField::class
+        ], ['type' => 'TableMaker']);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m190412_182837_tablemaker_update_fieldtype cannot be reverted.\n";
+        return false;
+    }
+}


### PR DESCRIPTION
Projects using TableMaker under Craft 2 currently don't have a migration path, these migrations handle the Craft 2 to Craft 3 when the Craft 3 plugin is installed.

Relates to #16.