### PR TITLE
Update tablemaker for Craft 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "supercool/tablemaker",
     "description": "A user-definable table field type for Craft CMS",
     "type": "craft-plugin",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "keywords": [
         "craft",
         "cms",
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.0.0-RC1"
+        "craftcms/cms": "^3.0.0-RC1 || ^4.0.0-beta"
     },
     "autoload": {
         "psr-4": {

--- a/src/assetbundles/field/dist/js/tablemaker.js
+++ b/src/assetbundles/field/dist/js/tablemaker.js
@@ -157,6 +157,9 @@ Craft.TableMaker = Garnish.Base.extend(
 
         this.columnsTable = new Craft.EditableTable(this.columnsTableId, this.columnsTableName, this.columnSettings, {
             rowIdPrefix: 'col',
+            allowAdd: true,
+            allowDelete: true,
+            allowReorder: true,
             onAddRow: $.proxy(this, 'onColumnsAddRow'),
             onDeleteRow: $.proxy(this, 'reconstructRowsTable')
         });
@@ -172,6 +175,9 @@ Craft.TableMaker = Garnish.Base.extend(
 
         this.rowsTable = new Craft.EditableTable(this.rowsTableId, this.rowsTableName, this.columns, {
             rowIdPrefix: 'row',
+            allowAdd: true,
+            allowDelete: true,
+            allowReorder: true,
             onAddRow: $.proxy(this, 'onRowsAddRow'),
             onDeleteRow: $.proxy(this, 'makeDataBlob')
         });

--- a/src/fields/TableMakerField.php
+++ b/src/fields/TableMakerField.php
@@ -68,7 +68,7 @@ class TableMakerField extends Field
      *
      * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         $rules = parent::rules();
         return $rules;
@@ -105,7 +105,7 @@ class TableMakerField extends Field
      *
      * @return mixed The prepared field value
      */
-    public function normalizeValue($value, ElementInterface $element = null)
+    public function normalizeValue(mixed $value, ElementInterface $element = null): mixed
     {
 
         if ( !is_array($value) )
@@ -188,7 +188,7 @@ class TableMakerField extends Field
      *
      * @return null|false `false` in the event that the method is sure that no elements are going to be found.
      */
-    public function serializeValue($value, ElementInterface $element = null)
+    public function serializeValue(mixed $value, ElementInterface $element = null): mixed
     {
 
         if ( !empty($value['rows']) && is_array($value['rows']) )
@@ -222,7 +222,7 @@ class TableMakerField extends Field
      *
      * @return string|null
      */
-    public function getSettingsHtml()
+    public function getSettingsHtml(): ?string
     {
         // Render the settings template
         return Craft::$app->getView()->renderTemplate(
@@ -243,7 +243,7 @@ class TableMakerField extends Field
      *
      * @return string The input HTML.
      */
-    public function getInputHtml($value, ElementInterface $element = null): string
+    public function getInputHtml(mixed $value, ElementInterface $element = null): string
     {
         $view = Craft::$app->getView();
 
@@ -340,33 +340,38 @@ class TableMakerField extends Field
 
         // render the two tables
         $fieldSettings = $this->getSettings();
-        $columnsField = $view->renderTemplateMacro('_includes/forms', 'editableTableField', array(
-            array(
-                'label' => $fieldSettings['columnsLabel'] ? Craft::t('tablemaker', $fieldSettings['columnsLabel']) : Craft::t('tablemaker', 'Table Columns'),
-                'instructions'  => $fieldSettings['columnsInstructions'] ? Craft::t('tablemaker', $fieldSettings['columnsInstructions']) : Craft::t('tablemaker', 'Define the columns your table should have.'),
-                'id'    => $columnsInputId,
-                'name'  => $columnsInput,
-                'cols'  => $columnSettings,
-                'rows'  => $columns,
-                'addRowLabel'   => $fieldSettings['columnsAddRowLabel'] ? Craft::t('tablemaker', $fieldSettings['columnsAddRowLabel']) : Craft::t('tablemaker', 'Add a column'),
-                'initJs'    => false
-            )
-        ));
 
-        $rowsField = $view->renderTemplateMacro('_includes/forms', 'editableTableField', array(
-            array(
-                'label' => $fieldSettings['rowsLabel'] ? Craft::t('tablemaker', $fieldSettings['rowsLabel']) : Craft::t('tablemaker', 'Table Content'),
-                'instructions'  => $fieldSettings['rowsInstructions'] ? Craft::t('tablemaker', $fieldSettings['rowsInstructions']) : Craft::t('tablemaker', 'Input the content of your table.'),
-                'id'                => $rowsInputId,
-                'name'              => $rowsInput,
-                'cols'              => $columns,
-                'rows'              => $rows,
-                'addRowLabel'       => $fieldSettings['rowsAddRowLabel'] ? Craft::t('tablemaker', $fieldSettings['rowsAddRowLabel']) : Craft::t('tablemaker', 'Add a row'),
-                'initJs'            => false
-            )
-        ));
+        $columnsField = $view->renderTemplate('_includes/forms/editableTable', [
+            'label'         => $fieldSettings['columnsLabel'] ? Craft::t('tablemaker', $fieldSettings['columnsLabel']) : Craft::t('tablemaker', 'Table Columns'),
+            'instructions'  => $fieldSettings['columnsInstructions'] ? Craft::t('tablemaker', $fieldSettings['columnsInstructions']) : Craft::t('tablemaker', 'Define the columns your table should have.'),
+            'id'            => $columnsInputId,
+            'name'          => $columnsInput,
+            'cols'          => $columnSettings,
+            'rows'          => $columns,
+            'static'        => false,
+            'allowAdd'      => true,
+            'allowDelete'   => true,
+            'allowReorder'  => true,
+            'addRowLabel'   => $fieldSettings['columnsAddRowLabel'] ? Craft::t('tablemaker', $fieldSettings['columnsAddRowLabel']) : Craft::t('tablemaker', 'Add a column'),
+            'initJs'        => false
+        ]);
 
-        return $input . $columnsField . $rowsField;
+        $rowsField = $view->renderTemplate('_includes/forms/editableTable', [
+            'label'             => $fieldSettings['rowsLabel'] ? Craft::t('tablemaker', $fieldSettings['rowsLabel']) : Craft::t('tablemaker', 'Table Content'),
+            'instructions'      => $fieldSettings['rowsInstructions'] ? Craft::t('tablemaker', $fieldSettings['rowsInstructions']) : Craft::t('tablemaker', 'Input the content of your table.'),
+            'id'                => $rowsInputId,
+            'name'              => $rowsInput,
+            'cols'              => $columns,
+            'rows'              => $rows,
+            'static'            => false,
+            'allowAdd'          => true,
+            'allowDelete'       => true,
+            'allowReorder'      => true,
+            'addRowLabel'       => $fieldSettings['rowsAddRowLabel'] ? Craft::t('tablemaker', $fieldSettings['rowsAddRowLabel']) : Craft::t('tablemaker', 'Add a row'),
+            'initJs'            => false
+        ]);
+
+        return $input . $columnsField . '<br />' . $rowsField;
     }
 
 


### PR DESCRIPTION
I think this project is probably dead (based on the lack of response to issues / PRs) but I'll be keeping a fork of this alive over at https://github.com/upstatement/tablemaker. In case I'm wrong, here's a PR to upgrade Tablemaker to use Craft 4. 

The biggest change here is that `renderTemplateMacro` was deprecated in 3.6 and is removed completely in 4.0, so it refactors a bit to use `renderTemplate` instead. Table permissions have also changed, which has necessitated a few new parameters being added. 